### PR TITLE
Add support of `CYUSB3` driver running under `libusbK`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
-# libusb-cmake
+# libusb-cmake fork
 
-This is the _**community**-supported_ CMake build system for [libusb] project.
+This is a fork of the _**community**-supported_ CMake build system for [libusb](https://github.com/libusb/libusb) project.
 
-The _officially-supported_ build system for [libusb] remains Autotools, as part of the [libusb] main repo.
+The _officially-supported_ build system for **libusb** remains Autotools, as part of the **libusb** main repo.
 
-NOTE: [libusb/](libusb/) subfolder is a git [subtree](https://www.atlassian.com/git/tutorials/git-subtree). Do not attempt to contribute to it - use an upstream [libusb] repo for that purpose.
+# Build
 
-## Use cases
+## Configure CMake
 
-The main use case as of this moment - using libusb as a [subdirectory](https://cmake.org/cmake/help/latest/command/add_subdirectory.html). Depending on the needs of the host project `libusb` may be built with different options, with or w/o installing binaries, etc. 
+### MSVC
+```bash
+cmake -S . -B build -G "Visual Studio 17 2022" -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -DLIBUSB_ENABLE_LOGGING="OFF"
+```
+### Ninja
+```bash
+cmake -S . -B build -G "Ninja Multi-Config" -DLIBUSB_ENABLE_LOGGING="OFF"
+```
 
----
+## Build
 
-More details: TBD.
+### MSVC
+```bash
+cmake --build build --config Release --target ALL_BUILD -j28
+```
+### Ninja
+```bash
+cmake --build build --config Release --target generated
+```
 
-[libusb]: https://github.com/libusb/libusb
+Libusb repo: https://github.com/libusb/libusb

--- a/libusb/libusb/os/windows_winusb.c
+++ b/libusb/libusb/os/windows_winusb.c
@@ -2303,7 +2303,8 @@ static const char * const composite_driver_names[] = {
   "USBCCGP", // (Windows built-in) USB Composite Device
   "dg_ssudbus" // SAMSUNG Mobile USB Composite Device
 };
-static const char * const winusbx_driver_names[] = {"libusbK", "libusb0", "WinUSB"};
+// The list should match the list of definitions `SUB_API_` in `windows_winusb.h`.
+static const char * const winusbx_driver_names[] = {"libusbK", "libusb0", "CYUSB3", "WinUSB"};
 static const char * const hid_driver_names[] = {"HIDUSB", "MOUHID", "KBDHID"};
 const struct windows_usb_api_backend usb_api_backend[USB_API_MAX] = {
 	{
@@ -3096,7 +3097,7 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 	set_transfer_priv_handle(itransfer, handle_priv->interface_handle[current_interface].dev_handle);
 	overlapped = get_transfer_priv_overlapped(itransfer);
 
-	if ((sub_api == SUB_API_LIBUSBK) || (sub_api == SUB_API_LIBUSB0)) {
+	if ((sub_api > SUB_API_NOTSET) || (sub_api < SUB_API_WINUSB)) {
 		int i;
 		UINT offset;
 		size_t iso_ctx_size;
@@ -3434,7 +3435,7 @@ static enum libusb_transfer_status winusbx_copy_transfer_data(int sub_api, struc
 			return LIBUSB_TRANSFER_ERROR;
 
 		// for isochronous, need to copy the individual iso packet actual_lengths and statuses
-		if ((sub_api == SUB_API_LIBUSBK) || (sub_api == SUB_API_LIBUSB0)) {
+		if ((sub_api > SUB_API_NOTSET) || (sub_api < SUB_API_WINUSB)) {
 			// iso only supported on libusbk-based backends for now
 			PKISO_CONTEXT iso_context = transfer_priv->iso_context;
 			for (i = 0; i < transfer->num_iso_packets; i++) {

--- a/libusb/libusb/os/windows_winusb.h
+++ b/libusb/libusb/os/windows_winusb.h
@@ -61,11 +61,14 @@ DEFINE_GUID(GUID_DEVINTERFACE_LIBUSB0_FILTER, 0xF9F3FF14, 0xAE21, 0x48A0, 0x8A, 
 
 // Sub-APIs for WinUSB-like driver APIs (WinUSB, libusbK, libusb-win32 through the libusbK DLL)
 // Must have the same values as the KUSB_DRVID enum from libusbk.h
+// The list of definitions should match `winusbx_driver_names` list in `windows_winusb.c`.
+// If your device relies on `libusbK`, put it in between `SUB_API_NOTSET` and `SUB_API_WINUSB`.
 #define SUB_API_NOTSET		-1
 #define SUB_API_LIBUSBK		0
 #define SUB_API_LIBUSB0		1
-#define SUB_API_WINUSB		2
-#define SUB_API_MAX		3
+#define SUB_API_CYPRESS		2
+#define SUB_API_WINUSB		3
+#define SUB_API_MAX		4
 
 struct windows_usb_api_backend {
 	const uint8_t id;


### PR DESCRIPTION
After some [research](https://community.infineon.com/t5/USB-superspeed-peripherals/Using-libusb-to-interface-with-Cypress-FX3-USB-BootLoader-Device/td-p/213877) I found that `CYUSB3` is likely compatible with `libusbK`. 
Adjust the lib to use `libusbK` library for `CYUSB3`.