### PR TITLE
allow the library build on windows when CMAKE_UNITY_BUILD is globally on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ if(WIN32)
     )
     target_compile_definitions(usb-1.0 PRIVATE $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS=1>)
     target_link_libraries(usb-1.0 PRIVATE windowsapp)
+    set_target_properties(usb-1.0 PROPERTIES UNITY_BUILD OFF)
 else()
     # common POSIX/non-Windows sources
     target_sources(usb-1.0 PRIVATE


### PR DESCRIPTION
On Microsoft Windows, the library fails to build when CMAKE_UNITY_BUILD is globally turned on. However, on Linux, it just works fine.

``` sh
$ cmake -S . -B build -DCMAKE_UNITY_BUILD=ON
$ cmake --build build
MSBuild version 17.12.12+1cce77968 for .NET Framework

  1>Checking Build System
  Building Custom Rule C:/Users/mamadou/Desktop/dev/libusb-cmake/CMakeLists.txt
  unity_1_c.c
  unity_0_c.c
C:\Users\mamadou\Desktop\dev\libusb-cmake\libusb\libusb\os\windows_winusb.c(508,15): error C2040: 'windows_open': 'HANDLE (libusb_device_handle *,const char *,DWORD)' differs in levels of indirection from 'int (libusb_device_hand
le *)' [C:\Users\mamadou\Desktop\dev\libusb-cmake\build\usb-1.0.vcxproj]
  (compiling source file 'CMakeFiles/usb-1.0.dir/Unity/unity_1_c.c')

C:\Users\mamadou\Desktop\dev\libusb-cmake\libusb\libusb\os\windows_winusb.c(2592,65): error C2197: 'int windows_open(libusb_device_handle *)': too many arguments for call [C:\Users\mamadou\Desktop\dev\libusb-cmake\build\usb-1.0.v
cxproj]
  (compiling source file 'CMakeFiles/usb-1.0.dir/Unity/unity_1_c.c')

C:\Users\mamadou\Desktop\dev\libusb-cmake\libusb\libusb\os\windows_winusb.c(2592,85): error C2197: 'int windows_open(libusb_device_handle *)': too many arguments for call [C:\Users\mamadou\Desktop\dev\libusb-cmake\build\usb-1.0.v
cxproj]
  (compiling source file 'CMakeFiles/usb-1.0.dir/Unity/unity_1_c.c')

C:\Users\mamadou\Desktop\dev\libusb-cmake\libusb\libusb\os\windows_winusb.c(2796,46): error C2197: 'int windows_open(libusb_device_handle *)': too many arguments for call [C:\Users\mamadou\Desktop\dev\libusb-cmake\build\usb-1.0.v
cxproj]
  (compiling source file 'CMakeFiles/usb-1.0.dir/Unity/unity_1_c.c')

C:\Users\mamadou\Desktop\dev\libusb-cmake\libusb\libusb\os\windows_winusb.c(2796,72): error C2197: 'int windows_open(libusb_device_handle *)': too many arguments for call [C:\Users\mamadou\Desktop\dev\libusb-cmake\build\usb-1.0.v
cxproj]
  (compiling source file 'CMakeFiles/usb-1.0.dir/Unity/unity_1_c.c')

C:\Users\mamadou\Desktop\dev\libusb-cmake\libusb\libusb\os\windows_winusb.c(3975,64): error C2197: 'int windows_open(libusb_device_handle *)': too many arguments for call [C:\Users\mamadou\Desktop\dev\libusb-cmake\build\usb-1.0.v
cxproj]
  (compiling source file 'CMakeFiles/usb-1.0.dir/Unity/unity_1_c.c')

C:\Users\mamadou\Desktop\dev\libusb-cmake\libusb\libusb\os\windows_winusb.c(3975,84): error C2197: 'int windows_open(libusb_device_handle *)': too many arguments for call [C:\Users\mamadou\Desktop\dev\libusb-cmake\build\usb-1.0.v
cxproj]
  (compiling source file 'CMakeFiles/usb-1.0.dir/Unity/unity_1_c.c')

C:\Users\mamadou\Desktop\dev\libusb-cmake\libusb\libusb\os\windows_winusb.c(3985,65): error C2197: 'int windows_open(libusb_device_handle *)': too many arguments for call [C:\Users\mamadou\Desktop\dev\libusb-cmake\build\usb-1.0.v
cxproj]
  (compiling source file 'CMakeFiles/usb-1.0.dir/Unity/unity_1_c.c')

C:\Users\mamadou\Desktop\dev\libusb-cmake\libusb\libusb\os\windows_winusb.c(3985,72): error C2197: 'int windows_open(libusb_device_handle *)': too many arguments for call [C:\Users\mamadou\Desktop\dev\libusb-cmake\build\usb-1.0.v
cxproj]
  (compiling source file 'CMakeFiles/usb-1.0.dir/Unity/unity_1_c.c')

  Generating Code...
```

Why is this an issue? We have a large code base that benefits from Unity/Jumbo builds by significantly improving build times. Thus, it's globally turned on.

Adding libusb-cmake as a subfolder, however breaks the build:

```cmake
option(JUMBO_BUILD "Whether to enable unity mode for faster builds or not" ON)

if (JUMBO_BUILD)
    set(CMAKE_UNITY_BUILD ON)
else ()
    set(CMAKE_UNITY_BUILD OFF)
endif ()

add_subdirectory(third-party/libusb-cmake)
```

So, this one line fix/workaround disables the UNITY_BUIILD on the usb-1.0  target allowing it to be built without those confusing errors.
