### PR TITLE
Publish fork PR test results via workflow_run

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -424,21 +424,13 @@ jobs:
                   install/static/include/libusb-1.0/libusb.h"
           fail: true
 
-  publish-test-results:
-    name: "Publish Tests Results"
-    needs: [ubuntu-build, macos-build, windows-msvc-build, android-build]
+  event-file:
+    name: "Event File"
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      pull-requests: write
-    if: always()
 
     steps:
-    - name: Download Artifacts
-      uses: actions/download-artifact@v8
+    - name: Upload
+      uses: actions/upload-artifact@v7
       with:
-        path: artifacts
-    - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      with:
-        files: "artifacts/**/*.xml"
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,36 @@
+name: Test Results
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  publish-test-results:
+    name: "Publish Tests Results"
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      issues: read
+      actions: read
+
+    steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@v8
+      with:
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ github.token }}
+        path: artifacts
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        commit: ${{ github.event.workflow_run.head_sha }}
+        event_file: artifacts/Event File/event.json
+        event_name: ${{ github.event.workflow_run.event }}
+        files: "artifacts/**/*.xml"


### PR DESCRIPTION
`pull_request` runs from forked repos get a read-only `GITHUB_TOKEN`, so the in-CI publish job can't create checks or PR comments.

Publishing moves to a separate `workflow_run` workflow that runs with the base repository token: `builds.yml` only uploads the event file and test-result artifacts; `test-results.yml` downloads and publishes them after CI completes.

Takes effect once merged — `workflow_run` only triggers from the default branch.

Fixes: #22

Assisted-by: Claude-Code:claude-opus-4-7 [WebFetch] [gh]