### PR TITLE
Fix MSVC examples build broken by libusb v1.0.30 update

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,7 +12,8 @@ if(MSVC)
         "${LIBUSB_ROOT}/../msvc/getopt/getopt1.c"
     )
     # Need to pass HAVE_CONFIG_H so getopt.h can load the config header
-    target_compile_definitions(getoptMSVC PRIVATE HAVE_CONFIG_H)
+    # _GL_UNUSED: gnulib no-op attribute macro, empty for MSVC
+    target_compile_definitions(getoptMSVC PRIVATE HAVE_CONFIG_H _GL_UNUSED=)
     target_include_directories(getoptMSVC
         PUBLIC "${LIBUSB_ROOT}/../msvc/getopt/"
         PRIVATE "${LIBUSB_GEN_INCLUDES}"


### PR DESCRIPTION
The libusb v1.0.30 update (`bbe9413`) brought a `getopt.c` that uses the gnulib `_GL_UNUSED` macro, breaking the MSVC `getoptMSVC` build (`error C2143` in `_getopt_initialize`).

Define `_GL_UNUSED=` (empty) for the target, matching upstream's `msvc/getopt.vcxproj`.

Assisted-by: Claude-Code:claude-opus-4-7 [gh]