### PR TITLE
Add Cygwin and Fedora MinGW CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -145,16 +145,24 @@ jobs:
                   install/static/lib/libusb-1.0.a, \
                   install/static/include/libusb-1.0/libusb.h"
           fail: true
-      - name: Test Shared
+      - name: Test Shared/Static
         if: always()
-        working-directory: build/shared
         run: |
-          export PATH="$(pwd)/../../install/shared/bin:$PATH"
-          ctest --output-junit test_shared.xml ${{ env.COMMON_CTEST_ARGS }}
-      - name: Test Static
-        if: always()
-        working-directory: build/static
-        run: ctest --output-junit test_static.xml ${{ env.COMMON_CTEST_ARGS }}
+          set +e
+          (
+            export PATH="$PWD/install/shared/bin:$PATH"
+            ctest --test-dir build/shared --output-junit "$PWD/build/shared/test_shared.xml" ${{ env.COMMON_CTEST_ARGS }}
+          ) &
+          shared_pid=$!
+          ctest --test-dir build/static --output-junit "$PWD/build/static/test_static.xml" ${{ env.COMMON_CTEST_ARGS }} &
+          static_pid=$!
+          wait "$shared_pid"
+          shared_status=$?
+          wait "$static_pid"
+          static_status=$?
+          if (( shared_status != 0 || static_status != 0 )); then
+            exit 1
+          fi
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v7
@@ -272,10 +280,9 @@ jobs:
       uses: TheMrMilchmann/setup-msvc-dev@v4
       with:
         arch: x64
-    - name: Configure Visual Studio/UWP
+    - name: Configure Visual Studio
       run: |
         cmake -B build/msvc -S src -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/msvc -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=ON
-        cmake -B build/uwp -S src -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/uwp -DLIBUSB_BUILD_EXAMPLES=OFF -DLIBUSB_BUILD_TESTING=OFF -DLIBUSB_BUILD_SHARED_LIBS=ON
     - name: Configure NMake/Ninja
       shell: cmd
       run: |
@@ -285,9 +292,6 @@ jobs:
         cmake -GNinja -B build\ninja_static -DCMAKE_INSTALL_PREFIX=install/ninja_static -S src -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=OFF
     - name: Build Visual Studio
       working-directory: build/msvc
-      run: cmake --build . --config RelWithDebInfo --target install
-    - name: Build UWP
-      working-directory: build/uwp
       run: cmake --build . --config RelWithDebInfo --target install
     - name: Build NMake Shared
       working-directory: build/nmake_shared
@@ -311,9 +315,6 @@ jobs:
         files: "install/msvc/lib/usb-1.0.lib, \
                 install/msvc/bin/libusb-1.0.dll, \
                 install/msvc/include/libusb-1.0/libusb.h, \
-                install/uwp/lib/usb-1.0.lib, \
-                install/uwp/bin/libusb-1.0.dll, \
-                install/uwp/include/libusb-1.0/libusb.h, \
                 install/nmake_shared/lib/usb-1.0.lib, \
                 install/nmake_shared/bin/libusb-1.0.dll, \
                 install/nmake_shared/include/libusb-1.0/libusb.h, \
@@ -365,6 +366,33 @@ jobs:
           build/nmake_static/test_nmake_static.xml
           build/ninja_shared/test_ninja_shared.xml
           build/ninja_static/test_ninja_static.xml
+
+  windows-uwp-build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        path: src
+    - name: Set up MSVC for UWP
+      uses: TheMrMilchmann/setup-msvc-dev@v4
+      with:
+        arch: x64
+        uwp: true
+    - name: Configure
+      run: |
+        $sdkVersion = $env:WindowsSDKVersion.TrimEnd('\')
+        cmake -B build/uwp -S src -DCMAKE_SYSTEM_NAME=WindowsStore "-DCMAKE_SYSTEM_VERSION:STRING=$sdkVersion" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/uwp -DLIBUSB_BUILD_EXAMPLES=OFF -DLIBUSB_BUILD_TESTING=OFF -DLIBUSB_BUILD_SHARED_LIBS=ON
+    - name: Build
+      working-directory: build/uwp
+      run: cmake --build . --config RelWithDebInfo --target install
+    - name: Check artifacts
+      uses: andstor/file-existence-action@v3
+      with:
+        files: "install/uwp/lib/usb-1.0.lib, \
+                install/uwp/bin/libusb-1.0.dll, \
+                install/uwp/include/libusb-1.0/libusb.h"
+        fail: true
 
 
   android-build:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -122,11 +122,11 @@ jobs:
           path: src
       - name: Set Cygwin package cache key
         id: cygwin-cache-key
-        shell: pwsh
+        shell: bash
         run: |
-          $now = [DateTime]::UtcNow
-          $weekStart = $now.Date.AddDays(-(([int] $now.DayOfWeek + 6) % 7))
-          "suffix=$($weekStart.ToString('yyyy-MM-dd'))" >> $env:GITHUB_OUTPUT
+          days_since_monday=$(($(date -u +%u) - 1))
+          week_start=$(date -u --date="$days_since_monday days ago" +%F)
+          echo "suffix=$week_start" >> "$GITHUB_OUTPUT"
       - name: Cache Cygwin packages
         uses: actions/cache@v5
         with:
@@ -157,24 +157,16 @@ jobs:
                   install/static/lib/libusb-1.0.a, \
                   install/static/include/libusb-1.0/libusb.h"
           fail: true
-      - name: Test Shared/Static
+      - name: Test Shared
         if: always()
+        working-directory: build/shared
         run: |
-          set +e
-          (
-            export PATH="$PWD/install/shared/bin:$PATH"
-            ctest --test-dir build/shared --output-junit "$PWD/build/shared/test_shared.xml" ${{ env.COMMON_CTEST_ARGS }}
-          ) &
-          shared_pid=$!
-          ctest --test-dir build/static --output-junit "$PWD/build/static/test_static.xml" ${{ env.COMMON_CTEST_ARGS }} &
-          static_pid=$!
-          wait "$shared_pid"
-          shared_status=$?
-          wait "$static_pid"
-          static_status=$?
-          if (( shared_status != 0 || static_status != 0 )); then
-            exit 1
-          fi
+          export PATH="$(pwd)/../../install/shared/bin:$PATH"
+          ctest --output-junit test_shared.xml ${{ env.COMMON_CTEST_ARGS }}
+      - name: Test Static
+        if: always()
+        working-directory: build/static
+        run: ctest --output-junit test_static.xml ${{ env.COMMON_CTEST_ARGS }}
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -105,6 +105,65 @@ jobs:
           build/shared/test_shared.xml
           build/static/test_static.xml
 
+  windows-cygwin-build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+    env:
+      COMMON_CTEST_ARGS: --no-compress-output --output-on-failure
+
+    steps:
+      - name: Configure Git line endings
+        shell: pwsh
+        run: git config --global core.autocrlf input
+      - uses: actions/checkout@v6
+        with:
+          path: src
+      - name: Install dependencies
+        uses: cygwin/cygwin-install-action@v6
+        with:
+          install-dir: 'C:\cygwin'
+          packages: cmake gcc-core ninja
+      - name: Configure
+        run: |
+          rm -rf build install
+          cmake -B build/shared -S src -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/shared -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=ON
+          cmake -B build/static -S src -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/static -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=OFF
+      - name: Build Shared
+        working-directory: build/shared
+        run: ninja install
+      - name: Build Static
+        working-directory: build/static
+        run: ninja install
+      - name: Check artifacts
+        uses: andstor/file-existence-action@v3
+        with:
+          files: "install/shared/lib/libusb-1.0.dll.a, \
+                  install/shared/bin/libusb-1.0.dll, \
+                  install/shared/include/libusb-1.0/libusb.h, \
+                  install/static/lib/libusb-1.0.a, \
+                  install/static/include/libusb-1.0/libusb.h"
+          fail: true
+      - name: Test Shared
+        if: always()
+        working-directory: build/shared
+        run: |
+          export PATH="$(pwd)/../../install/shared/bin:$PATH"
+          ctest --output-junit test_shared.xml ${{ env.COMMON_CTEST_ARGS }}
+      - name: Test Static
+        if: always()
+        working-directory: build/static
+        run: ctest --output-junit test_static.xml ${{ env.COMMON_CTEST_ARGS }}
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: Test Results Cygwin
+          path: |
+            build/shared/test_shared.xml
+            build/static/test_static.xml
+
   windows-mingw-build:
     runs-on: windows-latest
     defaults:
@@ -152,6 +211,51 @@ jobs:
         if: always()
         working-directory: build/static
         run: ctest --output-junit test_static.xml ${{ env.COMMON_CTEST_ARGS }}
+
+  fedora-mingw-build:
+    runs-on: ubuntu-latest
+    container: fedora:latest
+
+    steps:
+      - name: Install dependencies
+        run: dnf install -y cmake git mingw32-gcc mingw64-gcc ninja-build
+      - uses: actions/checkout@v6
+        with:
+          path: src
+      - name: Configure
+        run: |
+          rm -rf build install
+          mingw32-cmake -B build/shared_32 -S src -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/shared_32 -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=ON
+          mingw32-cmake -B build/static_32 -S src -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/static_32 -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=OFF
+          mingw64-cmake -B build/shared_64 -S src -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/shared_64 -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=ON
+          mingw64-cmake -B build/static_64 -S src -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/static_64 -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=OFF
+      - name: Build Shared x86
+        working-directory: build/shared_32
+        run: ninja install
+      - name: Build Static x86
+        working-directory: build/static_32
+        run: ninja install
+      - name: Build Shared x64
+        working-directory: build/shared_64
+        run: ninja install
+      - name: Build Static x64
+        working-directory: build/static_64
+        run: ninja install
+      - name: Check artifacts
+        uses: andstor/file-existence-action@v3
+        with:
+          files: "install/shared_32/lib/libusb-1.0.dll.a, \
+                  install/shared_32/bin/libusb-1.0.dll, \
+                  install/shared_32/include/libusb-1.0/libusb.h, \
+                  install/static_32/lib/libusb-1.0.a, \
+                  install/static_32/include/libusb-1.0/libusb.h, \
+                  install/shared_64/lib/libusb-1.0.dll.a, \
+                  install/shared_64/bin/libusb-1.0.dll, \
+                  install/shared_64/include/libusb-1.0/libusb.h, \
+                  install/static_64/lib/libusb-1.0.a, \
+                  install/static_64/include/libusb-1.0/libusb.h"
+          fail: true
+    # No test runs/results: cross-compiled Windows binaries are not runnable on a Linux host
 
   windows-msvc-build:
     runs-on: windows-latest

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -109,13 +109,13 @@ jobs:
     runs-on: windows-latest
     defaults:
       run:
-        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+        shell: D:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
     env:
       COMMON_CTEST_ARGS: --no-compress-output --output-on-failure
 
     steps:
       - name: Configure Git line endings
-        shell: pwsh
+        shell: cmd
         run: git config --global core.autocrlf input
       - uses: actions/checkout@v6
         with:
@@ -123,7 +123,7 @@ jobs:
       - name: Install dependencies
         uses: cygwin/cygwin-install-action@v6
         with:
-          install-dir: 'C:\cygwin'
+          work-vol: 'D:'
           packages: cmake gcc-core ninja
       - name: Configure
         run: |
@@ -261,7 +261,6 @@ jobs:
     runs-on: windows-latest
     env:
       COMMON_CTEST_ARGS: --no-compress-output --output-on-failure
-      VCVARS64_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
 
     steps:
     - uses: actions/checkout@v6
@@ -269,13 +268,17 @@ jobs:
         path: src
     - name: Install dependencies
       run: choco install ninja
-    - name: Configure Visual Studio
+    - name: Set up MSVC
+      uses: TheMrMilchmann/setup-msvc-dev@v4
+      with:
+        arch: x64
+    - name: Configure Visual Studio/UWP
       run: |
         cmake -B build/msvc -S src -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/msvc -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=ON
+        cmake -B build/uwp -S src -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/uwp -DLIBUSB_BUILD_EXAMPLES=OFF -DLIBUSB_BUILD_TESTING=OFF -DLIBUSB_BUILD_SHARED_LIBS=ON
     - name: Configure NMake/Ninja
       shell: cmd
       run: |
-        call "${{ env.VCVARS64_PATH }}"
         cmake -G"NMake Makefiles" -B build\nmake_shared -DCMAKE_INSTALL_PREFIX=install/nmake_shared -S src -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=ON
         cmake -G"NMake Makefiles" -B build\nmake_static -DCMAKE_INSTALL_PREFIX=install/nmake_static -S src -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=OFF
         cmake -GNinja -B build\ninja_shared -DCMAKE_INSTALL_PREFIX=install/ninja_shared -S src -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBUSB_BUILD_EXAMPLES=ON -DLIBUSB_BUILD_TESTING=ON -DLIBUSB_BUILD_SHARED_LIBS=ON
@@ -283,36 +286,34 @@ jobs:
     - name: Build Visual Studio
       working-directory: build/msvc
       run: cmake --build . --config RelWithDebInfo --target install
+    - name: Build UWP
+      working-directory: build/uwp
+      run: cmake --build . --config RelWithDebInfo --target install
     - name: Build NMake Shared
       working-directory: build/nmake_shared
       shell: cmd
-      run: |
-        call "${{ env.VCVARS64_PATH }}"
-        nmake install
+      run: nmake install
     - name: Build NMake Static
       working-directory: build/nmake_static
       shell: cmd
-      run: |
-        call "${{ env.VCVARS64_PATH }}"
-        nmake install
+      run: nmake install
     - name: Build Ninja Shared
       working-directory: build/ninja_shared
       shell: cmd
-      run: |
-        call "${{ env.VCVARS64_PATH }}"
-        ninja install
+      run: ninja install
     - name: Build Ninja Static
       working-directory: build/ninja_static
       shell: cmd
-      run: |
-        call "${{ env.VCVARS64_PATH }}"
-        ninja install
+      run: ninja install
     - name: Check artifacts
       uses: andstor/file-existence-action@v3
       with:
         files: "install/msvc/lib/usb-1.0.lib, \
                 install/msvc/bin/libusb-1.0.dll, \
                 install/msvc/include/libusb-1.0/libusb.h, \
+                install/uwp/lib/usb-1.0.lib, \
+                install/uwp/bin/libusb-1.0.dll, \
+                install/uwp/include/libusb-1.0/libusb.h, \
                 install/nmake_shared/lib/usb-1.0.lib, \
                 install/nmake_shared/bin/libusb-1.0.dll, \
                 install/nmake_shared/include/libusb-1.0/libusb.h, \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -120,6 +120,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: src
+      - name: Set Cygwin package cache key
+        id: cygwin-cache-key
+        shell: pwsh
+        run: |
+          $now = [DateTime]::UtcNow
+          $weekStart = $now.Date.AddDays(-(([int] $now.DayOfWeek + 6) % 7))
+          "suffix=$($weekStart.ToString('yyyy-MM-dd'))" >> $env:GITHUB_OUTPUT
+      - name: Cache Cygwin packages
+        uses: actions/cache@v5
+        with:
+          path: 'D:\cygwin-packages'
+          key: cygwin-packages-v1-${{ runner.os }}-${{ steps.cygwin-cache-key.outputs.suffix }}
       - name: Install dependencies
         uses: cygwin/cygwin-install-action@v6
         with:
@@ -366,34 +378,6 @@ jobs:
           build/nmake_static/test_nmake_static.xml
           build/ninja_shared/test_ninja_shared.xml
           build/ninja_static/test_ninja_static.xml
-
-  windows-uwp-build:
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        path: src
-    - name: Set up MSVC for UWP
-      uses: TheMrMilchmann/setup-msvc-dev@v4
-      with:
-        arch: x64
-        uwp: true
-    - name: Configure
-      run: |
-        $sdkVersion = $env:WindowsSDKVersion.TrimEnd('\')
-        cmake -B build/uwp -S src -DCMAKE_SYSTEM_NAME=WindowsStore "-DCMAKE_SYSTEM_VERSION:STRING=$sdkVersion" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install/uwp -DLIBUSB_BUILD_EXAMPLES=OFF -DLIBUSB_BUILD_TESTING=OFF -DLIBUSB_BUILD_SHARED_LIBS=ON
-    - name: Build
-      working-directory: build/uwp
-      run: cmake --build . --config RelWithDebInfo --target install
-    - name: Check artifacts
-      uses: andstor/file-existence-action@v3
-      with:
-        files: "install/uwp/lib/usb-1.0.lib, \
-                install/uwp/bin/libusb-1.0.dll, \
-                install/uwp/include/libusb-1.0/libusb.h"
-        fail: true
-
 
   android-build:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ project(usb-1.0
     VERSION ${LIBUSB_VERSION}
     LANGUAGES C
 )
+
+if(CYGWIN)
+    # Match upstream's Cygwin build flags for the Windows backend.
+    add_compile_options(-mwin32)
+endif()
+
 if(EMSCRIPTEN)
     set(CMAKE_CXX_STANDARD 20)
     enable_language(CXX)
@@ -65,7 +71,7 @@ function(generate_config_file)
     endif()
 
     # Set vars that will be written into the config file.
-    if(WIN32)
+    if(WIN32 OR CYGWIN)
         set(PLATFORM_WINDOWS 1)
     else()
         set(PLATFORM_POSIX 1)
@@ -78,7 +84,7 @@ function(generate_config_file)
         set(ENABLE_DEBUG_LOGGING ${LIBUSB_ENABLE_DEBUG_LOGGING})
     endif()
 
-    if(WIN32 AND LIBUSB_ENABLE_WINDOWS_HOTPLUG)
+    if((WIN32 OR CYGWIN) AND LIBUSB_ENABLE_WINDOWS_HOTPLUG)
         set(LIBUSB_WINDOWS_HOTPLUG 1)
     endif()
 
@@ -116,7 +122,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     option(LIBUSB_ENABLE_UDEV "Enable udev backend for device enumeration" ON)
 endif()
 
-if(WIN32)
+if(WIN32 OR CYGWIN)
     option(LIBUSB_ENABLE_WINDOWS_HOTPLUG "Enable Windows hotplug support" OFF)
 endif()
 
@@ -176,7 +182,7 @@ target_include_directories(usb-1.0
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libusb-1.0>
 )
 
-if(WIN32)
+if(WIN32 OR CYGWIN)
     target_sources(usb-1.0 PRIVATE
         "${LIBUSB_ROOT}/libusb-1.0.def"
         "${LIBUSB_ROOT}/os/events_windows.c"


### PR DESCRIPTION
## Summary

- add native Cygwin shared/static builds, artifact checks, and CTest coverage
- select libusb's Windows backend under Cygwin and apply upstream's `-mwin32` compile flag
- add Fedora-hosted MinGW x86 and x64 shared/static cross-builds and artifact checks
- initialize MSVC with `TheMrMilchmann/setup-msvc-dev@v4`, avoiding assumptions about the Visual Studio version on `windows-latest`

## CI details

- Cygwin uses the official installer action on its documented faster `D:` volume, a bounded weekly download cache, the documented checkout line-ending setup, and sequential shared/static test suites.
- Fedora installs the distribution MinGW toolchains before checkout, then uses `mingw32-cmake` and `mingw64-cmake`.
- Cross-compiled Windows tests and examples are built but not executed on the Linux host.

## Platform audit

This closes the remaining platform gaps listed in #7. FreeBSD was deliberately replaced by NetBSD because it ships a system libusb; Solaris and Emscripten are already covered by OmniOS and Emscripten jobs. Haiku still lacks a CMake backend, so it is not an easy hosted-CI addition.

A hosted UWP probe was also evaluated. Configuration succeeds, but upstream libusb's Windows backend relies on desktop-only APIs such as SetupAPI and `CreateFile`, so UWP requires substantive backend work rather than another CI variant. Additional Windows/Android architectures and alternate toolchains remain useful follow-ups, but they are not missing platforms from #7.

## Validation

- `actionlint` 1.7.12 passes for both workflow files.
- The full hosted matrix passes at the final head; the unchanged macOS stress-test job passed on an isolated rerun after one runner hung.
- The final warm-cache Cygwin job completes in 3:24 versus 4:01 initially, while retaining sequential stress tests for reliability.
- Visual Studio, NMake, and Ninja shared/static builds and tests pass on `windows-latest` through `setup-msvc-dev`.
- A clean Visual Studio 2022 x64 build, install, and all four CTest tests pass locally.

Closes #7

Assisted-by: codex:gpt-5