### PR TITLE
Remove stale inline config placeholder

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -70,9 +70,3 @@
 
 /* Enable GNU extensions. */
 #cmakedefine _GNU_SOURCE 1
-
-/* Define to `__inline__' or `__inline' if that's what the C compiler
-   calls it, or to nothing if 'inline' is not supported under any name.  */
-#ifndef __cplusplus
-/* #undef inline */
-#endif


### PR DESCRIPTION
## Summary

- remove the inert `AC_C_INLINE` autoheader fragment from `config.h.in`
- leave inline compatibility to the existing supported paths: upstream's C11 compiler requirement and the MSVC fallback in `libusb.h`

CMake's `configure_file(... @ONLY)` copied `/* #undef inline */` verbatim, so the block never configured or undefined anything.

## Validation

- MSVC 19.44: shared library and examples built; 4/4 tests passed
- WSL/GCC 11.4 with Ninja: shared library, examples, and tests built; `set_option` and `init_context` passed
- generated `config.h` verified to contain no inline substitution block
- `git diff --check`

The full WSL stress run exceeded the local 90-second cap after the build completed; no process remained after timeout.

Fixes: #4

Assisted-by: codex:gpt-5
