### PR TITLE
Limit CMake HAVE probes to active backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,23 +40,45 @@ function(generate_config_file)
     include(CheckStructHasMember)
     include(CheckCCompilerFlag)
 
-    check_function_exists(clock_gettime             HAVE_CLOCK_GETTIME)
-    check_function_exists(pthread_condattr_setclock HAVE_PTHREAD_CONDATTR_SETCLOCK)
-    check_function_exists(pthread_setname_np        HAVE_PTHREAD_SETNAME_NP)
-    check_function_exists(pthread_threadid_np       HAVE_PTHREAD_THREADID_NP)
-    check_function_exists(eventfd                   HAVE_EVENTFD)
-    check_function_exists(pipe2                     HAVE_PIPE2)
-    check_function_exists(syslog                    HAVE_SYSLOG)
+    # The Windows backend needs a fallback when clock_gettime is unavailable.
+    # POSIX backends use it too, except on Apple platforms.
+    if(NOT APPLE)
+        check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
+    endif()
 
-    check_include_files(asm/types.h      HAVE_ASM_TYPES_H)
-    check_include_files(sys/eventfd.h    HAVE_EVENTFD)
-    check_include_files(string.h         HAVE_STRING_H)
-    check_include_files(sys/time.h       HAVE_SYS_TIME_H)
+    # The Windows backend needs to know whether it must provide struct timespec.
+    if(WIN32 OR CYGWIN)
+        check_struct_has_member("struct timespec" tv_sec time.h HAVE_STRUCT_TIMESPEC)
+    endif()
 
-    check_symbol_exists(timerfd_create  "sys/timerfd.h" HAVE_TIMERFD)
-    check_symbol_exists(nfds_t  "poll.h" HAVE_NFDS_T)
+    # Cygwin uses the Windows backend but still needs <sys/time.h>.
+    if(NOT WIN32 OR CYGWIN)
+        check_include_files(sys/time.h HAVE_SYS_TIME_H)
+    endif()
 
-    check_struct_has_member("struct timespec" tv_sec time.h HAVE_STRUCT_TIMESPEC)
+    # Android logging does not reach the syslog path in core.c.
+    if((NOT WIN32 OR CYGWIN) AND NOT ANDROID)
+        check_function_exists(syslog HAVE_SYSLOG)
+    endif()
+
+    # These checks control paths compiled only by the POSIX backend.
+    if(NOT (WIN32 OR CYGWIN))
+        check_function_exists(pthread_condattr_setclock HAVE_PTHREAD_CONDATTR_SETCLOCK)
+        check_function_exists(eventfd                   HAVE_EVENTFD)
+        check_function_exists(pipe2                     HAVE_PIPE2)
+
+        check_symbol_exists(timerfd_create "sys/timerfd.h" HAVE_TIMERFD)
+        check_symbol_exists(nfds_t        "poll.h"       HAVE_NFDS_T)
+
+        if(CMAKE_SYSTEM_NAME MATCHES "Linux" OR ANDROID)
+            check_include_files(asm/types.h      HAVE_ASM_TYPES_H)
+            check_function_exists(pthread_setname_np HAVE_PTHREAD_SETNAME_NP)
+        endif()
+
+        if(APPLE)
+            check_function_exists(pthread_threadid_np HAVE_PTHREAD_THREADID_NP)
+        endif()
+    endif()
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "GNU")
         check_c_compiler_flag("-fvisibility=hidden" HAVE_VISIBILITY)

--- a/config.h.in
+++ b/config.h.in
@@ -31,9 +31,6 @@
 /* #define to 1 if you have the `pthread_threadid_np' function. */
 #cmakedefine HAVE_PTHREAD_THREADID_NP 1
 
-/* #define to 1 if you have the <string.h> header file. */
-#cmakedefine HAVE_STRING_H 1
-
 /* #define to 1 if the system has the type `struct timespec'. */
 #cmakedefine HAVE_STRUCT_TIMESPEC 1
 


### PR DESCRIPTION
## Summary

- Limit feature probes to the platforms whose selected sources consume them.
- Remove the unused `HAVE_STRING_H` definition and the redundant `eventfd` header probe.
- Leave native Windows with only the `clock_gettime` fallback and `struct timespec` probes it needs.

## Why

The feature checks were largely unconditionally ported from Autotools, so Windows configured POSIX-only checks for code paths it never compiles.

## Validation

- Configured with MSVC 19.44 / Ninja; native Windows runs only the `clock_gettime` and `struct timespec` feature checks.
- Built library, examples, and tests successfully.
- Ran CTest successfully with the built DLL first on `PATH` (the known `set_option` test remains excluded, matching CI).

Closes #5

Generated by Codex (GPT-5.6 Sol).
