### PR TITLE
Enable set_option test on Ubuntu CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,8 +14,7 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
     env:
-      # set_option known to fail on Github Actions
-      COMMON_CTEST_ARGS: --no-compress-output --output-on-failure -E "^set_option$"
+      COMMON_CTEST_ARGS: --no-compress-output --output-on-failure
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Re-enable the `set_option` CTest on Ubuntu by removing its obsolete exclusion while retaining the existing failure-output flags.

## Root cause

The exclusion was added in #9 after a device-less GitHub runner exposed a use-after-free in the old upstream test. Upstream fixed that bug and then made zero-device environments an explicitly supported test case.

Related to #9.
Related to libusb/libusb#1374 and libusb/libusb#1379.

## Validation

- `git diff --check`
- WSL CMake/CTest in a zero-device environment: `set_option` passed all five internal checks.
- Current upstream Ubuntu CI passes `set_option` in its normal Linux configurations.

Assisted by Codex (GPT-5).